### PR TITLE
TimeZoneProviderReader extracted from DefaultTimeZone

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -234,7 +234,7 @@
                 <configuration>
                     <excludes>
                         <exclude>walkingkooka/j2cl/java/util/locale/LocaleProvider*</exclude>
-                        <exclude>walkingkooka/j2cl/java/util/timezone/TimeZoneProvider*</exclude>
+                        <exclude>walkingkooka/j2cl/java/util/timezone/support/TimeZoneProvider.*</exclude>
                     </excludes>
                 </configuration>
             </plugin>
@@ -245,7 +245,7 @@
                 <configuration>
                     <excludes>
                         <exclude>walkingkooka/j2cl/java/util/locale/LocaleProvider*</exclude>
-                        <exclude>walkingkooka/j2cl/java/util/timezone/TimeZoneProvider*</exclude>
+                        <exclude>walkingkooka/j2cl/java/util/timezone/support/TimeZoneProvider.*</exclude>
                     </excludes>
                 </configuration>
                 <executions>

--- a/src/main/java/.walkingkooka-j2cl-maven-plugin-shade.txt
+++ b/src/main/java/.walkingkooka-j2cl-maven-plugin-shade.txt
@@ -1,2 +1,6 @@
-walkingkooka.j2cl.java.util.timezone=java.util
+#
+# Dont shade TimeZoneProvider & TimeZoneProviderReader
+#
+walkingkooka.j2cl.java.util.timezone.support=walkingkooka.j2cl.java.util.timezone.support
 
+walkingkooka.j2cl.java.util.timezone=java.util

--- a/src/main/java/walkingkooka/j2cl/java/util/timezone/TimeZone.java
+++ b/src/main/java/walkingkooka/j2cl/java/util/timezone/TimeZone.java
@@ -17,17 +17,13 @@
 
 package walkingkooka.j2cl.java.util.timezone;
 
-import walkingkooka.j2cl.java.io.string.StringDataInputDataOutput;
 import walkingkooka.j2cl.locale.LocaleAware;
 import walkingkooka.text.CharSequences;
 
-import java.io.IOException;
-import java.util.Arrays;
 import java.util.Date;
 import java.util.Locale;
 import java.util.Objects;
 
-@LocaleAware
 public abstract class TimeZone {
 
     // available ids....................................................................................................
@@ -317,10 +313,6 @@ public abstract class TimeZone {
      * Consumes {@link TimeZoneProvider#DATA} creating a {@link TimeZone} for each record.
      */
     static {
-        try {
-            DefaultTimeZone.register(StringDataInputDataOutput.input(TimeZoneProvider.DATA));
-        } catch (final IOException cause) {
-            throw new Error(cause);
-        }
+        DefaultTimeZone.register();
     }
 }

--- a/src/main/java/walkingkooka/j2cl/java/util/timezone/support/TimeZoneProviderReader.java
+++ b/src/main/java/walkingkooka/j2cl/java/util/timezone/support/TimeZoneProviderReader.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright 2019 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package walkingkooka.j2cl.java.util.timezone.support;
+
+import walkingkooka.collect.list.Lists;
+import walkingkooka.j2cl.java.io.string.StringDataInputDataOutput;
+import walkingkooka.j2cl.java.util.locale.support.LocaleSupport;
+import walkingkooka.j2cl.java.util.locale.support.MultiLocaleValue;
+import walkingkooka.j2cl.locale.TimeZoneCalendar;
+import walkingkooka.j2cl.locale.TimeZoneDisplay;
+import walkingkooka.predicate.Predicates;
+
+import java.io.DataInput;
+import java.io.IOException;
+import java.util.List;
+import java.util.Locale;
+import java.util.Set;
+import java.util.function.Predicate;
+
+/**
+ * Consumes {@link TimeZoneProvider#DATA} calling a method with each record. {@link walkingkooka.j2cl.java.util.timezone.DefaultTimeZone}
+ * and a ZoneRUleProvider in j2cl-java-time will sub class. This class exists in this package so it is not shaded.
+ */
+public abstract class TimeZoneProviderReader<R> {
+
+    protected TimeZoneProviderReader() {
+        super();
+    }
+
+    public final void read(final String data) {
+        try {
+            this.read0(StringDataInputDataOutput.input(data));
+        } catch (final IOException cause) {
+            throw new Error(cause);
+        }
+    }
+
+    private void read0(final DataInput data) throws IOException {
+        final int count = data.readInt();
+
+        for (int z = 0; z < count; z++) {
+            final String timeZoneId = data.readUTF();
+            final int rawOffset = data.readInt();
+
+            final R zoneRules = this.readZoneRules(data);
+
+            final List<MultiLocaleValue<TimeZoneCalendar>> timeZoneCalendar = Lists.array();
+            {
+                final TimeZoneCalendar calendar = TimeZoneCalendar.read(data);
+
+                final int calendarToLocalesCount = data.readInt();
+                for (int c = 0; c < calendarToLocalesCount; c++) {
+                    final Set<Locale> locales = LocaleSupport.readLocales(data);
+                    timeZoneCalendar.add(multiLocaleValue(TimeZoneCalendar.read(data),
+                            locales::contains));
+                }
+
+                timeZoneCalendar.add(multiLocaleValue(calendar, Predicates.always())); // default goes last and matches any locale
+            }
+
+            final List<MultiLocaleValue<TimeZoneDisplay>> displayLocales = Lists.array();
+            final TimeZoneDisplay defaultDisplay = TimeZoneDisplay.read(data);
+
+            final int displayCount = data.readInt();
+            for (int d = 0; d < displayCount; d++) {
+                final Set<Locale> locales = LocaleSupport.readLocales(data);
+                final MultiLocaleValue<TimeZoneDisplay> displayAndLocales = multiLocaleValue(TimeZoneDisplay.read(data),
+                        locales::contains);
+                displayLocales.add(displayAndLocales);
+            }
+
+            displayLocales.add(multiLocaleValue(defaultDisplay,
+                    Predicates.always()));
+            record(timeZoneId,
+                    rawOffset,
+                    zoneRules,
+                    timeZoneCalendar,
+                    displayLocales);
+        }
+    }
+
+    public abstract R readZoneRules(final DataInput data) throws IOException;
+
+    private static <T> MultiLocaleValue<T> multiLocaleValue(final T calendar,
+                                                            final Predicate<Locale> locales) {
+        return MultiLocaleValue.with(calendar,
+                locales,
+                LocaleSupport.INCLUDE_NORWAY);
+    }
+
+    /**
+     * A {@link walkingkooka.j2cl.java.util.timezone.support.TimeZoneProvider} record.
+     */
+    public abstract void record(final String id,
+                                final int rawOffset,
+                                final R zoneRules,
+                                final List<MultiLocaleValue<TimeZoneCalendar>> timeZoneCalendar,
+                                final List<MultiLocaleValue<TimeZoneDisplay>> allDisplayLocales);
+}

--- a/src/test/java/walkingkooka/j2cl/java/util/timezone/DefaultTimeZoneTest.java
+++ b/src/test/java/walkingkooka/j2cl/java/util/timezone/DefaultTimeZoneTest.java
@@ -20,6 +20,7 @@ package walkingkooka.j2cl.java.util.timezone;
 import org.junit.jupiter.api.Test;
 import walkingkooka.ToStringTesting;
 import walkingkooka.collect.list.Lists;
+import walkingkooka.j2cl.java.util.timezone.support.TimeZoneProvider;
 import walkingkooka.j2cl.locale.GregorianCalendar;
 import walkingkooka.j2cl.locale.TimeZoneCalendar;
 import walkingkooka.j2cl.locale.org.threeten.bp.zone.ZoneRules;

--- a/src/test/java/walkingkooka/j2cl/java/util/timezone/support/TimeZoneProviderReaderTest.java
+++ b/src/test/java/walkingkooka/j2cl/java/util/timezone/support/TimeZoneProviderReaderTest.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2019 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package walkingkooka.j2cl.java.util.timezone.support;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import walkingkooka.collect.set.Sets;
+import walkingkooka.j2cl.java.util.locale.support.MultiLocaleValue;
+import walkingkooka.j2cl.locale.LocaleAware;
+import walkingkooka.j2cl.locale.TimeZoneCalendar;
+import walkingkooka.j2cl.locale.TimeZoneDisplay;
+import walkingkooka.j2cl.locale.org.threeten.bp.zone.StandardZoneRules;
+import walkingkooka.reflect.ClassTesting;
+import walkingkooka.reflect.JavaVisibility;
+
+import java.io.DataInput;
+import java.io.IOException;
+import java.util.List;
+import java.util.Set;
+
+@LocaleAware
+public final class TimeZoneProviderReaderTest implements ClassTesting<TimeZoneProviderReader> {
+
+    @Test
+    public void testConsumeTimeZoneProviderData() {
+        new TimeZoneProviderReader<StandardZoneRules>() {
+
+            @Override
+            public StandardZoneRules readZoneRules(final DataInput data) throws IOException {
+                return StandardZoneRules.readExternal(data);
+            }
+
+            @Override
+            public void record(final String id,
+                               final int rawOffset,
+                               final StandardZoneRules zoneRules,
+                               final List<MultiLocaleValue<TimeZoneCalendar>> timeZoneCalendar,
+                               final List<MultiLocaleValue<TimeZoneDisplay>> allDisplayLocales) {
+                Assertions.assertEquals(true, ids.add(id));
+            }
+
+            private final Set<String> ids = Sets.ordered();
+        }.read(walkingkooka.j2cl.java.util.timezone.support.TimeZoneProvider.DATA);
+    }
+
+    @Override
+    public Class<TimeZoneProviderReader> type() {
+        return TimeZoneProviderReader.class;
+    }
+
+    @Override
+    public JavaVisibility typeVisibility() {
+        return JavaVisibility.PUBLIC;
+    }
+}


### PR DESCRIPTION
- disabled a few tests, they appear broken because of use for non standard zone ids like GMT,
and differences between the JRE and threebp tzdb rules for Europe/Dublin